### PR TITLE
Update subgraph-liquidity-range-example.py

### DIFF
--- a/subgraph-liquidity-range-example.py
+++ b/subgraph-liquidity-range-example.py
@@ -105,7 +105,7 @@ current_range_bottom_tick = current_tick // tick_spacing * tick_spacing
 
 # Sum up all tokens in the pool
 total_amount0 = 0
-total_amount1 = 1
+total_amount1 = 0
 
 # Iterate over the tick map starting from the bottom
 tick = min_tick


### PR DESCRIPTION
`total_amount1` should be initialised as `0`, not `1`? (I don't see any reason why it should start as `1`?)