### PR TITLE
Update subgraph-liquidity-range-example.py

### DIFF
--- a/subgraph-liquidity-range-example.py
+++ b/subgraph-liquidity-range-example.py
@@ -150,8 +150,8 @@ while tick < max_tick:
         adjusted_amount0actual = amount0actual / 10 ** decimals0
         adjusted_amount1actual = amount1actual / 10 ** decimals1
 
-        total_amount0 += adjusted_amount0
-        total_amount1 += adjusted_amount1
+        total_amount0 += adjusted_amount0actual
+        total_amount1 += adjusted_amount1actual
 
         print("        {:.2f} {} and {:.2f} {} remaining in the current tick range".format(
             adjusted_amount0actual, token0, adjusted_amount1actual, token1))


### PR DESCRIPTION
For current price tick, should be adding `adjusted_amountNactual` to the total? Otherwise it'll be double-counting, since `adjusted_amountN` is the "single-asset" hypothetical number?