### PR TITLE
adding package requirements to make sure all scripts run

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
-gql
-requests
-requests_toolbelt
+gql[all]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 gql
+requests
+requests_toolbelt


### PR DESCRIPTION
Hey I just checked all the scripts and turns out there are some missing dependencies in the `requirements.txt`. 
Specifically script `subgraph-liquidity-range-example.py` requires packages `requests` and `requests_toolbelt`. 
I've added these packages to the `requrements.txt` file 